### PR TITLE
Fix ChainId switch

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -123,13 +123,11 @@ public:
         consensus.defaultAssumeValid = uint256S("0xbf1c1d3b185bcd6585c95c1efd7d83da3b41c512200abbf6416638bc94179914"); // 151010
 
         // AuxPoW parameters
+        consensus.nAuxpowChainIds = {0x0062, 0x0032}; // All future chain IDs. Used for permissive block header checks.
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
-
-        // AuxPow2 parameters
-        consensus.nAuxpowChainIdRetargetHeight = INT_MAX; // Make sure we don't switch at the start
 
         // Blocks 5000 - 7500 are Digishield without AuxPoW
         digishieldConsensus = consensus;
@@ -146,11 +144,10 @@ public:
 
         // AuxPow2
         aux2Consensus = auxpowConsensus;
-        aux2Consensus.nAuxpowChainIdNew = 0x0032;
-        aux2Consensus.nAuxpowChainIdRetargetHeight = INT_MAX;
-        aux2Consensus.fStrictChainId = true;
-        aux2Consensus.fAllowLegacyBlocks = true;
         aux2Consensus.nHeightEffective = INT_MAX;
+        aux2Consensus.nAuxpowChainId = 0x0032;
+        aux2Consensus.fStrictChainId = true;
+        aux2Consensus.fAllowLegacyBlocks = false;
 
         // Assemble the binary search tree of consensus parameters
         pConsensusRoot = &digishieldConsensus; // 5000
@@ -281,13 +278,11 @@ public:
         consensus.defaultAssumeValid = uint256S("0x6943eaeaba98dc7d09f7e73398daccb4abcabb18b66c8c875e52b07638d93951"); // 900,000
 
         // AuxPoW parameters
+        consensus.nAuxpowChainIds = {0x0062, 0x0032}; // All future chain IDs. Used for permissive block header checks.
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = true;
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true;
-
-        // AuxPow2 parameters
-        consensus.nAuxpowChainIdRetargetHeight = INT_MAX; // Make sure we don't switch at the start
 
         // Blocks 145000 - 157499 are Digishield without minimum difficulty on all blocks
         digishieldConsensus = consensus;
@@ -312,11 +307,10 @@ public:
 
         // AuxPow2
         aux2Consensus = minDifficultyConsensus;
-        aux2Consensus.nAuxpowChainIdNew = 0x0032;
-        aux2Consensus.nAuxpowChainIdRetargetHeight = 25;
-        aux2Consensus.fStrictChainId = true;
-        aux2Consensus.fAllowLegacyBlocks = true;
         aux2Consensus.nHeightEffective = 25;
+        aux2Consensus.nAuxpowChainId = 0x0032;
+        aux2Consensus.fStrictChainId = true;
+        aux2Consensus.fAllowLegacyBlocks = false;
 
         // Assemble the binary search tree of parameters
         pConsensusRoot = &digishieldConsensus; // 5
@@ -421,13 +415,11 @@ public:
         consensus.defaultAssumeValid = uint256S("0x00");
 
         // AuxPow parameters
+        consensus.nAuxpowChainIds = {0x0062, 0x0032}; // All future chain IDs. Used for permissive block header checks.
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
-
-        // AuxPow2 parameters
-        consensus.nAuxpowChainIdRetargetHeight = INT_MAX; // Make sure we don't switch at the start
 
         // Dingocoin parameters
         consensus.fSimplifiedRewards = true;
@@ -444,11 +436,10 @@ public:
 
         // AuxPow2
         aux2Consensus = auxpowConsensus;
-        aux2Consensus.nAuxpowChainIdNew = 0x0032;
-        aux2Consensus.nAuxpowChainIdRetargetHeight = 50;
+        aux2Consensus.nHeightEffective = 25;
+        aux2Consensus.nAuxpowChainId = 0x0032;
         aux2Consensus.fStrictChainId = true;
         aux2Consensus.fAllowLegacyBlocks = false;
-        aux2Consensus.nHeightEffective = 25;
 
         // Assemble the binary search tree of parameters
         pConsensusRoot = &digishieldConsensus; // 10

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -128,6 +128,9 @@ public:
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
 
+        // AuxPow2 parameters
+        consensus.nAuxpowChainIdRetargetHeight = INT_MAX; // Make sure we don't switch at the start
+
         // Blocks 5000 - 7500 are Digishield without AuxPoW
         digishieldConsensus = consensus;
         digishieldConsensus.nHeightEffective = 5000;
@@ -283,6 +286,9 @@ public:
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true;
 
+        // AuxPow2 parameters
+        consensus.nAuxpowChainIdRetargetHeight = INT_MAX; // Make sure we don't switch at the start
+
         // Blocks 145000 - 157499 are Digishield without minimum difficulty on all blocks
         digishieldConsensus = consensus;
         digishieldConsensus.nHeightEffective = 5;
@@ -419,6 +425,9 @@ public:
         consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
+
+        // AuxPow2 parameters
+        consensus.nAuxpowChainIdRetargetHeight = INT_MAX; // Make sure we don't switch at the start
 
         // Dingocoin parameters
         consensus.fSimplifiedRewards = true;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -76,6 +76,11 @@ public:
     CMainParams() {
         strNetworkID = "main";
 
+        genesis = CreateGenesisBlock(1386325540, 99943, 0x1e0ffff0, 1, 88 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+        assert(consensus.hashGenesisBlock == uint256S("0x1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"));
+        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
+
         // Blocks 0 - 4999 are conventional difficulty calculation
         consensus.nSubsidyHalvingInterval = 100000;
         consensus.nMajorityEnforceBlockUpgrade = 1500;
@@ -123,14 +128,6 @@ public:
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
 
-        // AuxPow2
-        aux2Consensus = consensus;
-        aux2Consensus.nAuxpowChainIdNew = 0x0032;
-        aux2Consensus.nAuxpowChainIdRetargetHeight = INT_MAX;
-        aux2Consensus.fStrictChainId = true;
-        aux2Consensus.fAllowLegacyBlocks = true;
-        aux2Consensus.nHeightEffective = INT_MAX;
-
         // Blocks 5000 - 7500 are Digishield without AuxPoW
         digishieldConsensus = consensus;
         digishieldConsensus.nHeightEffective = 5000;
@@ -144,11 +141,19 @@ public:
         auxpowConsensus.nHeightEffective = 7500;
         auxpowConsensus.fAllowLegacyBlocks = false;
 
+        // AuxPow2
+        aux2Consensus = auxpowConsensus;
+        aux2Consensus.nAuxpowChainIdNew = 0x0032;
+        aux2Consensus.nAuxpowChainIdRetargetHeight = INT_MAX;
+        aux2Consensus.fStrictChainId = true;
+        aux2Consensus.fAllowLegacyBlocks = true;
+        aux2Consensus.nHeightEffective = INT_MAX;
+
         // Assemble the binary search tree of consensus parameters
-        pConsensusRoot = &digishieldConsensus;
-        digishieldConsensus.pLeft = &consensus;
-        digishieldConsensus.pRight = &auxpowConsensus;
-        auxpowConsensus.pRight = &aux2Consensus;
+        pConsensusRoot = &digishieldConsensus; // 5000
+        pConsensusRoot->InsertConsensus(&consensus); // 0
+        pConsensusRoot->InsertConsensus(&auxpowConsensus); // 7500
+        pConsensusRoot->InsertConsensus(&aux2Consensus); // INT_MAX
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -162,14 +167,6 @@ public:
         vAlertPubKey = ParseHex("04d4da7a5dae4db797d9b0644d57a5cd50e05a70f36091cd62e2fc41c98ded06340be5a43a35e185690cd9cde5d72da8f6d065b499b06f51dcfba14aad859f443a");
         nDefaultPort = 33117;
         nPruneAfterHeight = 100000;
-
-        genesis = CreateGenesisBlock(1386325540, 99943, 0x1e0ffff0, 1, 88 * COIN);
-
-        consensus.hashGenesisBlock = genesis.GetHash();
-        digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        assert(consensus.hashGenesisBlock == uint256S("0x1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"));
-        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
 
         // Note that of those with the service bits flag, most only support a subset of possible options
         vSeeds.push_back(CDNSSeedData("139.180.181.92", "139.180.181.92", true));
@@ -232,6 +229,11 @@ public:
     CTestNetParams() {
         strNetworkID = "test";
 
+        genesis = CreateGenesisBlock(1391503289, 997879, 0x1e0ffff0, 1, 88 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+        assert(consensus.hashGenesisBlock == uint256S("0xbb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e"));
+        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
+
         // Blocks 0 - 144999 are pre-Digishield
         consensus.nHeightEffective = 0;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
@@ -270,7 +272,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = INT_MAX;
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000000001030d1382ade");
+        consensus.nMinimumChainWork = uint256S("0x00");
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x6943eaeaba98dc7d09f7e73398daccb4abcabb18b66c8c875e52b07638d93951"); // 900,000
@@ -281,14 +283,6 @@ public:
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true;
 
-        // AuxPow2
-        aux2Consensus = consensus;
-        aux2Consensus.nAuxpowChainIdNew = 0x0032;
-        aux2Consensus.nAuxpowChainIdRetargetHeight = 25;
-        aux2Consensus.fStrictChainId = true;
-        aux2Consensus.fAllowLegacyBlocks = true;
-        aux2Consensus.nHeightEffective = 25;
-
         // Blocks 145000 - 157499 are Digishield without minimum difficulty on all blocks
         digishieldConsensus = consensus;
         digishieldConsensus.nHeightEffective = 5;
@@ -298,24 +292,32 @@ public:
         digishieldConsensus.fPowAllowMinDifficultyBlocks = false;
         digishieldConsensus.nCoinbaseMaturity = 240;
 
-        // Blocks 157500 - 158099 are Digishield with minimum difficulty on all blocks
-        minDifficultyConsensus = digishieldConsensus;
-        minDifficultyConsensus.nHeightEffective = 15;
-        minDifficultyConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
-        minDifficultyConsensus.fPowAllowMinDifficultyBlocks = true;
-
         // Enable AuxPoW at 158100
-        auxpowConsensus = minDifficultyConsensus;
+        auxpowConsensus = digishieldConsensus;
         auxpowConsensus.nHeightEffective = 10;
         auxpowConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
         auxpowConsensus.fAllowLegacyBlocks = false;
 
+        // Blocks 157500 - 158099 are Digishield with minimum difficulty on all blocks
+        minDifficultyConsensus = auxpowConsensus;
+        minDifficultyConsensus.nHeightEffective = 15;
+        minDifficultyConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
+        minDifficultyConsensus.fPowAllowMinDifficultyBlocks = true;
+
+        // AuxPow2
+        aux2Consensus = minDifficultyConsensus;
+        aux2Consensus.nAuxpowChainIdNew = 0x0032;
+        aux2Consensus.nAuxpowChainIdRetargetHeight = 25;
+        aux2Consensus.fStrictChainId = true;
+        aux2Consensus.fAllowLegacyBlocks = true;
+        aux2Consensus.nHeightEffective = 25;
+
         // Assemble the binary search tree of parameters
-        pConsensusRoot = &digishieldConsensus;
-        digishieldConsensus.pLeft = &consensus;
-        digishieldConsensus.pRight = &minDifficultyConsensus;
-        minDifficultyConsensus.pRight = &auxpowConsensus;
-        auxpowConsensus.pRight = &aux2Consensus;
+        pConsensusRoot = &digishieldConsensus; // 5
+        pConsensusRoot->InsertConsensus(&consensus); // 0
+        pConsensusRoot->InsertConsensus(&auxpowConsensus); // 10
+        pConsensusRoot->InsertConsensus(&minDifficultyConsensus); // 15
+        pConsensusRoot->InsertConsensus(&aux2Consensus); // 25
 
         pchMessageStart[0] = 0xfc;
         pchMessageStart[1] = 0xc1;
@@ -324,14 +326,6 @@ public:
         vAlertPubKey = ParseHex("042756726da3c7ef515d89212ee1705023d14be389e25fe15611585661b9a20021908b2b80a3c7200a0139dd2b26946606aab0eef9aa7689a6dc2c7eee237fa834");
         nDefaultPort = 44556;
         nPruneAfterHeight = 1000;
-
-        genesis = CreateGenesisBlock(1391503289, 997879, 0x1e0ffff0, 1, 88 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
-        digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        minDifficultyConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        assert(consensus.hashGenesisBlock == uint256S("0xbb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e"));
-        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -381,6 +375,13 @@ private:
 public:
     CRegTestParams() {
         strNetworkID = "regtest";
+
+        genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 88 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+        assert(consensus.hashGenesisBlock == uint256S("0x3d2160a3b5dc4a9d62e7e66a295f70313ac808440ef7400d6c0772171ce973a5"));
+        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
+
+        consensus.hashGenesisBlock = genesis.GetHash();
         consensus.nSubsidyHalvingInterval = 150;
         consensus.nMajorityEnforceBlockUpgrade = 12;
         consensus.nMajorityRejectBlockOutdated = 13;
@@ -419,14 +420,6 @@ public:
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
 
-        // AuxPow2
-        aux2Consensus = auxpowConsensus;
-        aux2Consensus.nAuxpowChainIdNew = 0x0032;
-        aux2Consensus.nAuxpowChainIdRetargetHeight = 25;
-        aux2Consensus.fStrictChainId = true;
-        aux2Consensus.fAllowLegacyBlocks = false;
-        aux2Consensus.nHeightEffective = 25;
-
         // Dingocoin parameters
         consensus.fSimplifiedRewards = true;
         consensus.nCoinbaseMaturity = 60; // For easier testability in RPC tests
@@ -440,11 +433,19 @@ public:
         auxpowConsensus.fAllowLegacyBlocks = false;
         auxpowConsensus.nHeightEffective = 20;
 
+        // AuxPow2
+        aux2Consensus = auxpowConsensus;
+        aux2Consensus.nAuxpowChainIdNew = 0x0032;
+        aux2Consensus.nAuxpowChainIdRetargetHeight = 50;
+        aux2Consensus.fStrictChainId = true;
+        aux2Consensus.fAllowLegacyBlocks = false;
+        aux2Consensus.nHeightEffective = 25;
+
         // Assemble the binary search tree of parameters
-        digishieldConsensus.pLeft = &consensus;
-        digishieldConsensus.pRight = &auxpowConsensus;
-        pConsensusRoot = &digishieldConsensus;
-        auxpowConsensus.pRight = &aux2Consensus;
+        pConsensusRoot = &digishieldConsensus; // 10
+        pConsensusRoot->InsertConsensus(&consensus); // 0
+        pConsensusRoot->InsertConsensus(&auxpowConsensus); // 20
+        pConsensusRoot->InsertConsensus(&aux2Consensus); // 25
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
@@ -452,13 +453,6 @@ public:
         pchMessageStart[3] = 0xda;
         nDefaultPort = 18444;
         nPruneAfterHeight = 1000;
-
-        genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 88 * COIN);
-        consensus.hashGenesisBlock = genesis.GetHash();
-        digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        assert(consensus.hashGenesisBlock == uint256S("0x3d2160a3b5dc4a9d62e7e66a295f70313ac808440ef7400d6c0772171ce973a5"));
-        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
@@ -502,8 +496,8 @@ const CChainParams &Params() {
 }
 
 const Consensus::Params *Consensus::Params::GetConsensus(uint32_t nTargetHeight) const {
-    if (nTargetHeight < this -> nHeightEffective && this -> pLeft != NULL) {
-        return this -> pLeft -> GetConsensus(nTargetHeight);
+    if (nTargetHeight < this->nHeightEffective && this->pLeft != NULL) {
+        return this->pLeft->GetConsensus(nTargetHeight);
     } else if (nTargetHeight > this -> nHeightEffective && this -> pRight != NULL) {
         const Consensus::Params *pCandidate = this -> pRight -> GetConsensus(nTargetHeight);
         if (pCandidate->nHeightEffective <= nTargetHeight) {
@@ -513,6 +507,24 @@ const Consensus::Params *Consensus::Params::GetConsensus(uint32_t nTargetHeight)
 
     // No better match below the target height
     return this;
+}
+
+void Consensus::Params::InsertConsensus(Consensus::Params* item) {
+  if (item->nHeightEffective < this->nHeightEffective) {
+    if (this->pLeft == NULL) {
+      this->pLeft = item;
+    } else {
+      this->pLeft->InsertConsensus(item);
+    }
+  } else if (item->nHeightEffective > this->nHeightEffective) {
+    if (this->pRight == NULL) {
+      this->pRight = item;
+    } else {
+      this->pRight->InsertConsensus(item);
+    }
+  } else {
+    throw std::runtime_error(strprintf("Duplicate consensus.nHeightEffective: %d", item->nHeightEffective));
+  }
 }
 
 CChainParams& Params(const std::string& chain)

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -9,6 +9,7 @@
 #include "uint256.h"
 #include <map>
 #include <string>
+#include <vector>
 
 namespace Consensus {
 
@@ -76,10 +77,8 @@ struct Params {
     uint256 defaultAssumeValid;
 
     /** Auxpow parameters */
-    int nAuxpowChainIdRetargetHeight;
     int32_t nAuxpowChainId;
-    int32_t nAuxpowChainIdNew;
-    int64_t ChainIdRetarget() const { return nAuxpowChainId; }
+    std::vector<int32_t> nAuxpowChainIds; // Includes all possible future chainIds.
     bool fStrictChainId;
     bool fAllowLegacyBlocks;
 
@@ -89,14 +88,6 @@ struct Params {
     struct Params *pRight = nullptr;     // Right hand branch
     const Consensus::Params *GetConsensus(uint32_t nTargetHeight) const;
     void InsertConsensus(Consensus::Params* item);
-
-    // The ChainIdRetargetHeight will need to know which ChainId to point to
-    int64_t ChainIdRetargetAtHeight(unsigned nHeight) const {
-        if(nHeight >= nAuxpowChainIdRetargetHeight) {
-            return nAuxpowChainIdNew;
-        }
-        return nAuxpowChainId;
-    }
 
 
 };

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -88,6 +88,7 @@ struct Params {
     struct Params *pLeft = nullptr;      // Left hand branch
     struct Params *pRight = nullptr;     // Right hand branch
     const Consensus::Params *GetConsensus(uint32_t nTargetHeight) const;
+    void InsertConsensus(Consensus::Params* item);
 
     // The ChainIdRetargetHeight will need to know which ChainId to point to
     int64_t ChainIdRetargetAtHeight(unsigned nHeight) const {

--- a/src/dingocoin.cpp
+++ b/src/dingocoin.cpp
@@ -88,7 +88,6 @@ unsigned int CalculateDingocoinNextWorkRequired(const CBlockIndex* pindexLast, i
 
 bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& params)
 {
-    int nHeight;
     /* Except for legacy blocks with full version 1, ensure that
        the chain ID is correct.  Legacy blocks are not allowed since
        the merge-mining start, which is checked in AcceptBlockHeader

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     nHeight = pindexPrev->nHeight + 1;
 
     const Consensus::Params& consensus = chainparams.GetConsensus(nHeight);
-    const int32_t nChainId = consensus.ChainIdRetargetAtHeight(nHeight);
+    const int32_t nChainId = consensus.nAuxpowChainId;
     // FIXME: Active version bits after the always-auxpow fork!
     // const int32_t nVersion = ComputeBlockVersion(pindexPrev, consensus);
     const int32_t nVersion = VERSIONBITS_LAST_OLD_BLOCK_VERSION;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     nHeight = pindexPrev->nHeight + 1;
 
     const Consensus::Params& consensus = chainparams.GetConsensus(nHeight);
-    const int32_t nChainId = consensus.nAuxpowChainId;
+    const int32_t nChainId = consensus.ChainIdRetargetAtHeight(nHeight);
     // FIXME: Active version bits after the always-auxpow fork!
     // const int32_t nVersion = ComputeBlockVersion(pindexPrev, consensus);
     const int32_t nVersion = VERSIONBITS_LAST_OLD_BLOCK_VERSION;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2856,8 +2856,45 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, bool f
     // We don't have block height as this is called without context (i.e. without
     // knowing the previous block), but that's okay, as the checks done are permissive
     // (i.e. doesn't check work limit or whether AuxPoW is enabled)
-    if (fCheckPOW && !CheckAuxPowProofOfWork(block, Params().GetConsensus(0)))
-        return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
+
+
+    // We can't check auxpow here because aux chain id is dependent on height with child switch.
+    //if (fCheckPOW && !CheckAuxPowProofOfWork(block, Params().GetConsensus(0)))
+    //    return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
+
+
+    // Contents below check as much as possible, adapting the code of CheckAuxPowProofOfWork.
+    if (fCheckPOW) {
+        const Consensus::Params& params = Params().GetConsensus(0);
+        if (!block.IsLegacy() && params.fStrictChainId &&
+            std::find(params.nAuxpowChainIds.begin(), params.nAuxpowChainIds.end(), block.GetChainId()) == params.nAuxpowChainIds.end()) {
+            return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "unaccepted chain id");
+        }
+
+        if (!block.auxpow) {
+            if (block.IsAuxpow())
+                return error("%s : no auxpow on block with auxpow version",
+                             __func__);
+
+            if (!CheckProofOfWork(block.GetPoWHash(), block.nBits, params))
+                return error("%s : non-AUX proof of work failed", __func__);
+
+            return true;
+        }
+
+        // We have auxpow.  Check it.
+
+        if (!block.IsAuxpow())
+            return error("%s : auxpow on block with non-auxpow version", __func__);
+
+
+        // Can't do these since current aux chain id is not known.
+        //if (!block.auxpow->check(block.GetHash(), block.GetChainId(), params))
+        //    return error("%s : AUX POW is not valid", __func__);
+        //if (!CheckProofOfWork(block.auxpow->getParentBlockPoWHash(), block.nBits, params))
+        //    return error("%s : AUX proof of work failed", __func__);
+        //
+    }
 
     return true;
 }
@@ -3003,7 +3040,7 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
     return commitment;
 }
 
-bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
+bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const CBlockIndex* pindexPrev, int64_t nAdjustedTime, bool fCheckPOW)
 {
     const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
     const Consensus::Params& consensusParams = Params().GetConsensus(nHeight);
@@ -3024,9 +3061,15 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
                                     __func__, pindexPrev->nHeight + 1, consensusParams.nHeightEffective),
                          REJECT_INVALID, "early-auxpow-block");
 
-    // Check proof of work
+    // Check bits for pow.
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
-        return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
+        return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work requirement");
+
+    // Check auxpow.
+    if (fCheckPOW && !consensusParams.fAllowLegacyBlocks) {
+      if (!CheckAuxPowProofOfWork(block, consensusParams))
+        return state.DoS(50, error("%s : auxpow failed", __func__), REJECT_INVALID, "auxpow-failed");
+    }
 
     // Check timestamp against prev
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
@@ -3336,7 +3379,7 @@ bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams,
     indexDummy.nHeight = pindexPrev->nHeight + 1;
 
     // NOTE: CheckBlockHeader is called by CheckBlock
-    if (!ContextualCheckBlockHeader(block, state, pindexPrev, GetAdjustedTime()))
+    if (!ContextualCheckBlockHeader(block, state, pindexPrev, GetAdjustedTime(), fCheckPOW))
         return error("%s: Consensus::ContextualCheckBlockHeader: %s", __func__, FormatStateMessage(state));
     if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot))
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));

--- a/src/validation.h
+++ b/src/validation.h
@@ -215,7 +215,7 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to > than 2200MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 2200ULL * 1024 * 1024;
 
-/** 
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
@@ -226,7 +226,7 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 2200ULL * 1024 * 1024;
  *
  * Note that we guarantee that either the proof-of-work is valid on pblock, or
  * (and possibly also) BlockChecked will have been called.
- * 
+ *
  * Call without cs_main held.
  *
  * @param[in]   pblock  The block we want to process.
@@ -344,7 +344,7 @@ ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::D
 /** Get the block height at which the BIP9 deployment switched into the state for the block building on the current tip. */
 int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
-/** 
+/**
  * Count ECDSA signature operations the old-fashioned (pre-0.6) way
  * @return number of sigops this transaction's outputs will produce when spent
  * @see CTransaction::FetchInputs
@@ -353,7 +353,7 @@ unsigned int GetLegacySigOpCount(const CTransaction& tx);
 
 /**
  * Count ECDSA signature operations in pay-to-script-hash inputs.
- * 
+ *
  * @param[in] mapInputs Map of previous transactions that have outputs we're spending
  * @return maximum number of sigops required to validate this transaction's inputs
  * @see CTransaction::FetchInputs
@@ -437,7 +437,7 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = NULL
 
 /**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {
@@ -489,7 +489,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = t
 /** Context-dependent validity checks.
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const CBlockIndex* pindexPrev, int64_t nAdjustedTime);
+bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const CBlockIndex* pindexPrev, int64_t nAdjustedTime, bool fCheckPOW = true);
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const CBlockIndex* pindexPrev);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.


### PR DESCRIPTION
- Add helper method to insert stuff into the binary tree properly.
- Reorder params ordering according to `nHeightEffective`.
- Move genesis to before `consensus`.