### PR TITLE
ci: bust macOS depends cache when Xcode or SDK changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,10 @@ jobs:
 
       # depends/built must not be restored across Xcode/macOS SDK upgrades; stale
       # objects often break `make -C depends` with exit 2 on Apple Silicon runners.
+      # Use a step output (not hashFiles on a generated file): hashFiles is resolved
+      # from the committed tree at job start and would ignore a runtime fingerprint.
       - name: macOS SDK fingerprint for depends cache
+        id: macos_sdk
         run: |
           {
             sw_vers
@@ -269,8 +272,8 @@ jobs:
             xcrun --show-sdk-path
             xcrun --show-sdk-version 2>/dev/null || true
             xcrun -f clang | xargs clang --version | head -n 1
-          } > depends_sdk_fingerprint.txt
-          cat depends_sdk_fingerprint.txt
+          } | tee /tmp/macos_sdk_fingerprint.txt
+          echo "fingerprint=$(shasum -a 256 /tmp/macos_sdk_fingerprint.txt | cut -c1-20)" >> "$GITHUB_OUTPUT"
 
       - name: Dependency cache
         uses: actions/cache@v4
@@ -278,7 +281,7 @@ jobs:
           cache-name: depends
         with:
           path: ./depends/built
-          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*', '.github/workflows/ci.yml', 'depends_sdk_fingerprint.txt') }}
+          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*', '.github/workflows/ci.yml') }}-${{ steps.macos_sdk.outputs.fingerprint }}
 
       - name: Build depends
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,13 +259,26 @@ jobs:
           brew install autoconf automake libtool pkg-config gnu-sed openssl@3
           pip3 install setuptools --break-system-packages
 
+      # depends/built must not be restored across Xcode/macOS SDK upgrades; stale
+      # objects often break `make -C depends` with exit 2 on Apple Silicon runners.
+      - name: macOS SDK fingerprint for depends cache
+        run: |
+          {
+            sw_vers
+            xcodebuild -version
+            xcrun --show-sdk-path
+            xcrun --show-sdk-version 2>/dev/null || true
+            xcrun -f clang | xargs clang --version | head -n 1
+          } > depends_sdk_fingerprint.txt
+          cat depends_sdk_fingerprint.txt
+
       - name: Dependency cache
         uses: actions/cache@v4
         env:
           cache-name: depends
         with:
           path: ./depends/built
-          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*', '.github/workflows/ci.yml') }}
+          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*', '.github/workflows/ci.yml', 'depends_sdk_fingerprint.txt') }}
 
       - name: Build depends
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `arm64-macos` job in `.github/workflows/ci.yml` caches `depends/built` with a key derived only from `depends/packages/*` and the workflow file. When GitHub updates the `macos-15` runner image (new Xcode or macOS SDK), restoring that cache can leave prebuilt `depends` artifacts that are incompatible with the new toolchain. That commonly surfaces as `make -C depends` failing with **exit code 2**, which matches the failure on PR #49 where the failing step was **Build depends** (not the application code).

The `main.yml` macOS job does not use this cache, which helps explain why other macOS checks could succeed while `ci.yml` failed.

## Solution

Before the cache step, compute a fingerprint of `sw_vers`, `xcodebuild -version`, SDK path/version, and clang, hash it with SHA-256, and append a short digest to the depends cache key. Any image upgrade invalidates the cache and forces a clean `depends` rebuild.

The fingerprint is passed via a **step output**, not `hashFiles()` on a generated file: `hashFiles` is resolved from the committed tree at job start and would not change when a prior step writes a file.

## Testing

Not run locally (workflow-only change). After merge, re-run CI on affected PRs or wait for the next push; the first macOS run after an image bump may be slower due to a cold cache.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3630f3e0-c99b-4d69-98ce-99f66d138a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3630f3e0-c99b-4d69-98ce-99f66d138a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

