### PR TITLE
ci: retry apt-get update and tune Acquire timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     name: ${{ matrix.name }}
 
     env:
+      DEBIAN_FRONTEND: noninteractive
       MAKEJOBS: "-j3"
       CHECK_DOC: "0"
       CCACHE_SIZE: "100M"
@@ -90,7 +91,7 @@ jobs:
             os: ubuntu-22.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 bc wine-binfmt
             postinstall: |
-              sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
+              sudo dpkg -s mono-runtime && sudo apt-get -y remove mono-runtime || echo "Very nothing to uninstall."
               sudo update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++  /usr/bin/x86_64-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
@@ -107,7 +108,7 @@ jobs:
             os: ubuntu-22.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 bc wine-binfmt
             postinstall: |
-              sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
+              sudo dpkg -s mono-runtime && sudo apt-get -y remove mono-runtime || echo "Very nothing to uninstall."
               sudo update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++  /usr/bin/x86_64-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
@@ -139,11 +140,25 @@ jobs:
 
       - name: Install packages
         run: |
-          sudo apt-get update
-          sudo apt-get install build-essential libtool autotools-dev automake \
+          printf '%s\n' \
+            'Acquire::Retries "5";' \
+            'Acquire::http::Timeout "120";' \
+            'Acquire::https::Timeout "120";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+          for attempt in 1 2 3 4 5; do
+            if sudo apt-get update -y; then
+              break
+            fi
+            echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+            if [ "$attempt" -eq 5 ]; then
+              exit 1
+            fi
+            sleep 20
+          done
+          sudo apt-get install -y build-essential libtool autotools-dev automake \
                pkg-config bsdmainutils curl ca-certificates ccache rsync git \
                procps bison python3 python3-pip python3-setuptools python3-wheel
-          sudo apt-get install ${{ matrix.packages }}
+          sudo apt-get install -y ${{ matrix.packages }}
           python3 -m pip install setuptools==70.3.0 --upgrade
 
       - name: Install standard lief wheel

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,9 @@ on:
       - 'share/**'
       - 'qa/**'
 
+env:
+  DEBIAN_FRONTEND: noninteractive
+
 jobs:
   analyze:
     name: Analyze
@@ -39,8 +42,20 @@ jobs:
 
     - name: Update system
       run: |
-        sudo apt-get update --yes
-        sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils --yes
+        printf '%s\n' \
+          'Acquire::Retries "5";' \
+          'Acquire::http::Timeout "120";' \
+          'Acquire::https::Timeout "120";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+        for attempt in 1 2 3 4 5; do
+          if sudo apt-get update -y; then
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+          if [ "$attempt" -eq 5 ]; then exit 1; fi
+          sleep 20
+        done
+        sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils
 
     - name: Dependency cache
       uses: actions/cache@v4

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,6 +8,7 @@ on:
     - develop
 env:
   SOURCE_ARTIFACT: ${{ github.workspace }}/source
+  DEBIAN_FRONTEND: noninteractive
 jobs:
   create-source-distribution:
     name: Create Source Distribution
@@ -19,15 +20,27 @@ jobs:
       uses: actions/checkout@v2
     - name: Install Required Packages
       run: |
-        sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
-        sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
-        sudo apt-get install libboost-all-dev
-        sudo apt-get install libdb5.3-dev libdb5.3++-dev
-        sudo apt-get update
-        sudo apt-get install libminiupnpc-dev
-        sudo apt-get install libzmq3-dev
-        sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
-        sudo apt-get install libqrencode-dev
+        printf '%s\n' \
+          'Acquire::Retries "5";' \
+          'Acquire::http::Timeout "120";' \
+          'Acquire::https::Timeout "120";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+        for attempt in 1 2 3 4 5; do
+          if sudo apt-get update -y; then
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+          if [ "$attempt" -eq 5 ]; then exit 1; fi
+          sleep 20
+        done
+        sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
+        sudo apt-get install -y libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+        sudo apt-get install -y libboost-all-dev
+        sudo apt-get install -y libdb5.3-dev libdb5.3++-dev
+        sudo apt-get install -y libminiupnpc-dev
+        sudo apt-get install -y libzmq3-dev
+        sudo apt-get install -y libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
+        sudo apt-get install -y libqrencode-dev
     - name: Create Distribution Tarball
       run: |
         ./autogen.sh
@@ -65,7 +78,19 @@ jobs:
       working-directory: ${{ env.SOURCE_ARTIFACT }}
     - name: Install Required Packages
       run: |
-        sudo apt-get update
+        printf '%s\n' \
+          'Acquire::Retries "5";' \
+          'Acquire::http::Timeout "120";' \
+          'Acquire::https::Timeout "120";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+        for attempt in 1 2 3 4 5; do
+          if sudo apt-get update -y; then
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+          if [ "$attempt" -eq 5 ]; then exit 1; fi
+          sleep 20
+        done
         sudo apt-get install -y python3-zmq
     - name: Build Dependencies
       run: make -C depends -j$(nproc)
@@ -102,7 +127,19 @@ jobs:
       working-directory: ${{ env.SOURCE_ARTIFACT }}
     - name: Install Required Packages
       run: |
-        sudo apt-get update
+        printf '%s\n' \
+          'Acquire::Retries "5";' \
+          'Acquire::http::Timeout "120";' \
+          'Acquire::https::Timeout "120";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+        for attempt in 1 2 3 4 5; do
+          if sudo apt-get update -y; then
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+          if [ "$attempt" -eq 5 ]; then exit 1; fi
+          sleep 20
+        done
         sudo apt-get install -y g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64
     - name: Switch MinGW GCC and G++ to POSIX Threading
       run: |
@@ -143,9 +180,21 @@ jobs:
     steps:
       - name: Install packages
         run: |
-          sudo apt-get update
-          sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps bison
-          sudo apt-get install ${{ env.packages }}
+          printf '%s\n' \
+            'Acquire::Retries "5";' \
+            'Acquire::http::Timeout "120";' \
+            'Acquire::https::Timeout "120";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+          for attempt in 1 2 3 4 5; do
+            if sudo apt-get update -y; then
+              break
+            fi
+            echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+            if [ "$attempt" -eq 5 ]; then exit 1; fi
+            sleep 20
+          done
+          sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps bison
+          sudo apt-get install -y ${{ env.packages }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: SDK cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ on:
     - Develop-Doge-Parity
 env:
   SOURCE_ARTIFACT: ${{ github.workspace }}/source
+  DEBIAN_FRONTEND: noninteractive
 jobs:
   create-source-distribution:
     name: Create Source Distribution
@@ -24,15 +25,27 @@ jobs:
       uses: actions/checkout@v2
     - name: Install Required Packages
       run: |
-        sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
-        sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
-        sudo apt-get install libboost-all-dev
-        sudo apt-get install libdb5.3-dev libdb5.3++-dev
-        sudo apt-get update
-        sudo apt-get install libminiupnpc-dev
-        sudo apt-get install libzmq3-dev
-        sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
-        sudo apt-get install libqrencode-dev
+        printf '%s\n' \
+          'Acquire::Retries "5";' \
+          'Acquire::http::Timeout "120";' \
+          'Acquire::https::Timeout "120";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+        for attempt in 1 2 3 4 5; do
+          if sudo apt-get update -y; then
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+          if [ "$attempt" -eq 5 ]; then exit 1; fi
+          sleep 20
+        done
+        sudo apt-get install -y build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
+        sudo apt-get install -y libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+        sudo apt-get install -y libboost-all-dev
+        sudo apt-get install -y libdb5.3-dev libdb5.3++-dev
+        sudo apt-get install -y libminiupnpc-dev
+        sudo apt-get install -y libzmq3-dev
+        sudo apt-get install -y libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
+        sudo apt-get install -y libqrencode-dev
     - name: Create Distribution Tarball
       run: |
         ./autogen.sh
@@ -69,7 +82,19 @@ jobs:
         tar -xzf dingocoin-*.tar.gz --strip-components=1
     - name: Install Required Packages
       run: |
-        sudo apt-get update
+        printf '%s\n' \
+          'Acquire::Retries "5";' \
+          'Acquire::http::Timeout "120";' \
+          'Acquire::https::Timeout "120";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+        for attempt in 1 2 3 4 5; do
+          if sudo apt-get update -y; then
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+          if [ "$attempt" -eq 5 ]; then exit 1; fi
+          sleep 20
+        done
         sudo apt-get install -y python3-zmq
     - name: Build Dependencies
       run: make -C depends -j$(nproc)
@@ -103,7 +128,19 @@ jobs:
         tar -xzf dingocoin-*.tar.gz --strip-components=1
     - name: Install Required Packages
       run: |
-        sudo apt-get update
+        printf '%s\n' \
+          'Acquire::Retries "5";' \
+          'Acquire::http::Timeout "120";' \
+          'Acquire::https::Timeout "120";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ci-retries >/dev/null
+        for attempt in 1 2 3 4 5; do
+          if sudo apt-get update -y; then
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/5), retrying in 20s..."
+          if [ "$attempt" -eq 5 ]; then exit 1; fi
+          sleep 20
+        done
         sudo apt-get install -y g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64
     - name: Switch MinGW GCC and G++ to POSIX Threading
       run: |


### PR DESCRIPTION
Write /etc/apt/apt.conf.d/99-ci-retries (Acquire::Retries, http/https timeouts) and retry apt-get update up to 5 times with backoff on Ubuntu runners. Set DEBIAN_FRONTEND=noninteractive where apt is used.

Fixes flaky hangs against azure.archive.ubuntu.com seen in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow shell steps and environment variables, primarily affecting package installation behavior on runners. The main risk is longer CI times or unexpected apt config interactions, not application runtime behavior.
> 
> **Overview**
> **CI reliability improvements for Ubuntu runners.** Workflows now set `DEBIAN_FRONTEND=noninteractive`, configure apt `Acquire::Retries` plus HTTP/HTTPS timeouts, and wrap `apt-get update` in a 5-attempt retry loop with sleep to reduce flaky mirror/network failures.
> 
> Package install commands are updated to use `-y` consistently, including `mono-runtime` removal in Windows cross-build jobs, to avoid interactive prompts/hangs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1285b178bafdababe5b841d7850c7c36f354c80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->