### PR TITLE
qt: force light Aqua appearance on macOS for readable UI

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -97,6 +97,10 @@
   <key>NSHighResolutionCapable</key>
     <string>True</string>
 
+  <!-- Qt wallet styling assumes light UI; force Aqua appearance so macOS Dark Mode stays readable -->
+  <key>NSRequiresAquaSystemAppearance</key>
+    <true/>
+
   <key>LSAppNapIsDisabled</key>
     <string>True</string>
 


### PR DESCRIPTION
Set NSRequiresAquaSystemAppearance in the Qt app Info.plist so the wallet uses the light system appearance while the Mac can stay in Dark Mode. Fixes poor contrast from legacy Qt styling under macOS dark theme.